### PR TITLE
feat!: Bring your own HttpClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider files
+.idea/

--- a/Halforbit.ApiClient.Tests/ApiClientIntegrationTests.cs
+++ b/Halforbit.ApiClient.Tests/ApiClientIntegrationTests.cs
@@ -532,10 +532,8 @@ namespace Halforbit.ApiClient.Tests
             {
                 var elapsed = timer.Elapsed;
 
-                Assert.True(elapsed >= TimeSpan.FromSeconds(0 + 1 + 2 + 4));
-
-                Assert.True(elapsed < TimeSpan.FromSeconds(0 + 1 + 2 + 4 + 8));
-
+                Assert.InRange(elapsed, TimeSpan.FromSeconds(0 + 1 + 2 + 4), TimeSpan.FromSeconds(0 + 1 + 2 + 4 + 9));
+                
                 Assert.Equal(4, retryCount);
             }
         }

--- a/Halforbit.ApiClient/Extensions/RequestExtensions.Services.cs
+++ b/Halforbit.ApiClient/Extensions/RequestExtensions.Services.cs
@@ -1,6 +1,7 @@
 ﻿using Halforbit.ApiClient.Implementation;
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Halforbit.ApiClient
@@ -12,8 +13,13 @@ namespace Halforbit.ApiClient
             IRequestClient requestClient)
         {
             request = request ?? Request.Default;
-
             var services = request.Services;
+            
+            // Dispose the old RequestClient so we don't leak resources.
+            if (!ReferenceEquals(requestClient, services.RequestClient))
+            {
+                services.RequestClient?.Dispose();
+            }
 
             return request.Services(new RequestServices(
                 requestClient: requestClient,
@@ -293,6 +299,18 @@ namespace Halforbit.ApiClient
                 beforeRequestHandlers: services.BeforeRequestHandlers,
                 beforeRetryHandlers: services.BeforeRetryHandlers,
                 afterResponseHandlers: services.AfterResponseHandlers));
+        }
+
+        /// <summary>
+        /// Can be used to override the default HttpClient that would be used internally to process the requests.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="client"></param>
+        /// <returns></returns>
+        public static Request HttpClient(this Request request, HttpClient client)
+        {
+            request = request ?? Request.Default;
+            return request.RequestClient(new RequestClient(client));
         }
     }
 }

--- a/Halforbit.ApiClient/Interface/IRequestClient.cs
+++ b/Halforbit.ApiClient/Interface/IRequestClient.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Halforbit.ApiClient
 {
-    public interface IRequestClient
+    public interface IRequestClient : IDisposable
     {
         Task<Response> ExecuteAsync(Request request);
     }

--- a/Halforbit.ApiClient/Model/Request.cs
+++ b/Halforbit.ApiClient/Model/Request.cs
@@ -4,7 +4,7 @@ using System.Net;
 
 namespace Halforbit.ApiClient
 {
-    public class Request
+    public class Request : IDisposable
     {
         static readonly IReadOnlyDictionary<string, string> _emptyDictionary = new Dictionary<string, string>(0);
 
@@ -130,6 +130,11 @@ namespace Halforbit.ApiClient
                 allowedStatusCodes: source.AllowedStatusCodes,
                 defaultContentStatusCodes: source.DefaultContentStatusCodes,
                 tags: source.Tags);
+        }
+
+        public void Dispose()
+        {
+            Services.Dispose();
         }
     }
 }

--- a/Halforbit.ApiClient/Model/RequestServices.cs
+++ b/Halforbit.ApiClient/Model/RequestServices.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
 namespace Halforbit.ApiClient
 {
-    public class RequestServices
+    public class RequestServices : IDisposable
     {
         public RequestServices(
             IRequestClient requestClient,
@@ -50,7 +51,7 @@ namespace Halforbit.ApiClient
         public IReadOnlyList<BeforeRetryDelegate> BeforeRetryHandlers { get; }
 
         public static RequestServices Default => new RequestServices(
-            requestClient: Halforbit.ApiClient.RequestClient.Instance,
+            requestClient: Halforbit.ApiClient.RequestClient.Instance, 
             authorizationStrategy: default,
             retryStrategy: default,
             requestSerializer: JsonSerializer.Instance,
@@ -70,5 +71,10 @@ namespace Halforbit.ApiClient
             string requestUrl,
             HttpStatusCode statusCode,
             int retryCount);
+
+        public void Dispose()
+        {
+            RequestClient.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Provide the ability for a consumer to supply the HttpClient that will be used.

BREAKING CHANGE: IRequestClient interface now extends IDisposable.